### PR TITLE
Bump 1.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+bot:
+  automerge: True
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cwl-upgrader" %}
-{% set version = "1.2.3" %}
+{% set version = "1.2.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cwl-upgrader-{{ version }}.tar.gz
-  sha256: 3372b87af6ab6154716462f97561620eecd786798a68a2a64a98529340f52e1f
+  sha256: b25fc236407343d44cc830ac3f63eed395b8d872fc7e17db92cde583d4a3b2ec
 
 build:
   noarch: python
@@ -37,7 +37,6 @@ test:
 
 about:
   home: https://github.com/common-workflow-language/cwl-upgrader
-  summary: Common Workflow Language standalone document upgrader
   license: Apache-2.0
   license_file:
     - LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,10 @@ test:
   commands:
     - pip check
     - cwl-upgrader --help
+    - python -m pytest -n auto --pyargs cwlupgrader
   requires:
     - pip
+    - pytest-xdist
 
 about:
   home: https://github.com/common-workflow-language/cwl-upgrader


### PR DESCRIPTION
-  runs the tests
- enables automerge
- Remove extra summary line which was breaking the autoupgrader
 
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

